### PR TITLE
line items can only be added to open orders

### DIFF
--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -234,7 +234,7 @@ class Profile(ViewSet):
             """
 
             try:
-                open_order = Order.objects.get(customer=current_user)
+                open_order = Order.objects.get(customer=current_user, payment_type=None)
                 print(open_order)
             except Order.DoesNotExist as ex:
                 open_order = Order()


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

- added an argument to the GET ORM on 237

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

POST `/profile/cart` Creates a new line item in cart

```json
{
    "product_id": 88
}
```

PUT `orders/2` updates the order's payment_type and CLOSES the order

```json
{
    "payment_type":  4
}
```


**Response**

HTTP/1.1 200 OK

```json
{
    "id": 10,
    "product": {
        "id": 88,
        "name": "Element",
        "price": 1727.41,
        "number_sold": 0,
        "description": "2003 Honda",
        "quantity": 3,
        "created_date": "2019-05-28",
        "location": "Dukoh",
        "image_path": null,
        "average_rating": null
    }
}
```

## Testing

Description of how to test code...

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database
----
- [ ] PostMan
- [ ] Collections > Create a payment type
- [ ] send it!
---
--ADD Product to order
- [ ] Collections > Shopping Cart
- [ ] Order is currently open
- [ ]  add product to cart using POST code above
- [ ] -send it!
---
Now let's close the order
----
- [ ]  add a payment type using PUT code above and CLOSE the order
- [ ] send it!
---
 now Try to add a new item to that order
You're not allowed because the order is closed.

A new item is added to a new order.

## Related Issues

- Fixes #23 